### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.hyperic.org/external (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/external) result SSLHandshakeException).
* http://maven.hyperic.org/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/milestone) result SSLHandshakeException).
* http://maven.hyperic.org/release (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/release) result SSLHandshakeException).
* http://maven.hyperic.org/snapshot (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/snapshot) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences